### PR TITLE
(init) created mock of core messaging service and socket server for dev

### DIFF
--- a/client/core/core.module.js
+++ b/client/core/core.module.js
@@ -1,0 +1,5 @@
+(function () {
+  angular.module('app.core', [
+    'app.messaging'
+  ]);
+})();

--- a/client/core/messaging.js
+++ b/client/core/messaging.js
@@ -1,0 +1,58 @@
+// Handles communication between clients. Mocks out over 
+// local socket server for now.
+(function (){
+angular.module('app.messaging', [])
+  .factory('messenger', messenger);
+
+function messenger () {
+
+  var socket = new WebSocket('ws://127.0.0.1:3434');
+  var ready = false;
+  var sender;
+
+  return {
+    initAsUser: initAsUser, // TODO: deprecate once we have a user service
+    send: send,
+    broadcast: broadcast,
+    onmessage: onmessage,
+    onready: onready
+  };
+
+  function initAsUser (user) { 
+    sender = user;
+    send('', '', 'signin');
+  }
+ 
+  function onready (readyHandler) {
+    socket.onopen = function () {
+      ready = true;
+      readyHandler();
+    };
+  }
+
+  function onmessage (messageHandler) {
+    socket.onmessage = function (event) {
+      var data = JSON.parse(event.data);
+      messageHandler(data.sender, data.data, data.type);
+    };
+  }
+
+  function send (recipient, data, type) {
+    if (!sender) throw new Error('must instantiate a sender before you can send a message');
+    if (!ready) throw new Error('must wait until socket is open before you can send a message');
+
+    socket.send(JSON.stringify({
+      recipient: recipient,
+      data: data,
+      type: type,
+      sender: sender
+    }));
+  }
+
+  // if recipient is 'broadcast', the message gets sent to everyone except the sender
+  function broadcast (data, type) {
+    send('broadcast', data, type);
+  }
+
+}
+})();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "body-parser": "^1.12.2",
-    "express": "^4.12.3"
+    "express": "^4.12.3",
+    "ws": "^0.7.1"
   },
   "devDependencies": {},
   "engines": {

--- a/server/dev-socket.js
+++ b/server/dev-socket.js
@@ -1,0 +1,44 @@
+
+var WebSocketServer = require('ws').Server;
+var wsServer = new WebSocketServer({ port: 3434 });
+
+// Utility function to broadcast a message to all connected clients, 
+// totally indiscriminately
+// wsServer.broadcast = function (data) {
+//   this.clients.forEach(function (client) {
+//     client.send(data);  //send to all clients, including initial sender
+//   });
+// };
+
+// index of socket connections by user
+var connections = {};
+
+wsServer.on('connection', function (ws) {
+
+  ws.on('message', function (messageStr) {
+    console.log('new message' + messageStr);
+
+    var msg = JSON.parse(messageStr);
+
+    // the first message a new connection sends must be a 'signin' message
+    // so we can associate a use with a socket client
+    if (msg.type === 'signin') {
+      connections[msg.sender] = ws;
+
+    // if broadcast, cycle through registered connections and send them a message
+    } else if (msg.recipient === 'broadcast') {
+
+      for (var user in connections) {
+        if (user !== msg.sender) {
+          connections[user].send(messageStr);
+        }
+      }
+
+    } else {
+
+      var client = connections[msg.recipient];
+      if (client) client.send(messageStr);
+
+    }
+  });
+});


### PR DESCRIPTION
PR creates a mock messaging service we can use while doing local dev, to pass messages among devices without needing to have a running ChromeCast.

To use:
- run server/dev-socket.js from your terminal
- inject messenger service into your angular component
- initiate all message passing from the onready event handler (passing messages before then will result in an error)
