### PR TITLE
(init) created player module to handle player communication

### DIFF
--- a/client/core/core.module.js
+++ b/client/core/core.module.js
@@ -1,5 +1,6 @@
 (function () {
   angular.module('app.core', [
-    'app.messaging'
+    'app.messaging',
+    'app.player'
   ]);
 })();

--- a/client/core/messaging.js
+++ b/client/core/messaging.js
@@ -20,7 +20,7 @@ function messenger () {
 
   function initAsUser (user) { 
     sender = user;
-    send('', '', 'signin');
+    send('signin');
   }
  
   function onready (readyHandler) {
@@ -33,11 +33,12 @@ function messenger () {
   function onmessage (messageHandler) {
     socket.onmessage = function (event) {
       var data = JSON.parse(event.data);
-      messageHandler(data.sender, data.data, data.type);
+      messageHandler(data.type, data.data, data.sender);
     };
   }
 
-  function send (recipient, data, type) {
+  function send (type, data, recipient) {
+    if (!type) throw new Error('all messages must have a type');
     if (!sender) throw new Error('must instantiate a sender before you can send a message');
     if (!ready) throw new Error('must wait until socket is open before you can send a message');
 
@@ -51,7 +52,7 @@ function messenger () {
 
   // if recipient is 'broadcast', the message gets sent to everyone except the sender
   function broadcast (data, type) {
-    send('broadcast', data, type);
+    send(type, data, 'broadcast');
   }
 
 }


### PR DESCRIPTION
This PR introduces a 'player' service that will allow the player client to communicate with the ChromeCast. It currently uses the mocked-out messenger service.

Changes include:
- create player service, with (1) methods to send game-play related messages to the ChromeCast, and (2) ability to listen for events triggered by ChromeCast
- reorder the parameters on messenger.send to a more usable order
- add app.player as a module-level dependency of app.core
