### PR TITLE
(feat) Added button to start a new round

### DIFF
--- a/client/chromecast-app/core/game.js
+++ b/client/chromecast-app/core/game.js
@@ -3,13 +3,33 @@
   angular.module('app.game', [])
     .factory('game', function (gameMessenger, $rootScope) {
 
+      // setup once per game
       var players = [];
       var playersReady = 0;
-      var judge;
-      var prompt;
-      var memes = [];   
-      var winner;   
 
+      // updated each round
+      var judgeIndex = 0;
+      var rounds = [];
+      var currentRound;
+
+      var startRound = function() {
+        currentRound = {
+          judge: players[judgeIndex],
+          memes: []
+        };
+        rounds.push(currentRound);
+        judgeIndex = (judgeIndex + 1) % players.length;
+
+        // notify controllers
+        trigger('gameStart');
+
+        // notify players
+        for (var i=0; i<players.length; i++) {
+          gameMessenger.start(players[i].name, { role: players[i] === currentRound.judge ? 'judge' : 'player' });
+        }
+      };
+
+      // Game-level events
       gameMessenger.on('playerJoined', function(data, sender) {
         var player = { name: sender };
         players.push(player);
@@ -22,20 +42,17 @@
       gameMessenger.on('ready', function(data, sender) {
         playersReady++;
         if (playersReady >= 3 && playersReady === players.length) {
-          judge = players[0];
-          trigger('gameStart');
-          for (var i=0; i<players.length; i++) {
-            gameMessenger.start(players[i].name, { role: players[i] === judge ? 'judge' : 'player' });
-          }
+          startRound();
         }
       });
 
+      // Round-level events
       gameMessenger.on('submit', function(data, sender) {
         if (data.prompt) {
+          currentRound.prompt = data.prompt;
           trigger('promptSubmitted', data.prompt);
-          prompt = data.prompt;
           for (var i=0; i<players.length; i++) {
-            if (players[i] !== judge) {
+            if (players[i] !== currentRound.judge) {
               gameMessenger.promptSubmitted(players[i].name, data);
             }
           }
@@ -45,27 +62,30 @@
           for (var i=0; i<players.length; i++) {
             if (players[i].name === sender) {
               players[i].meme = data.meme;
-              memes.push({ name: players[i].name, meme: data.meme });
+              currentRound.memes.push({ name: players[i].name, meme: data.meme });
               break;
             }
           }
-          if (memes.length === players.length-1) {
+          if (currentRound.memes.length === players.length-1) {
             trigger('allSubmitted');
-            gameMessenger.startJudging(judge.name, { memes: memes });
+            gameMessenger.startJudging(currentRound.judge.name, { memes: currentRound.memes });
           }
         }
       });
 
       gameMessenger.on('selectWinner', function(data, sender) {
+        currentRound.winner = data;
         trigger('winnerSelected', data);
-        winner = data;
         gameMessenger.done();
       });
 
-      // Building event handling system
+      gameMessenger.on('startNextRound', function () {
+        startRound();
+        trigger('startNextRound');
+      });
 
+      // Event handling
       var eventHandlers = {};
-
       var registerEventHandler = function(event, handler) {
         eventHandlers[event] = handler;
       };
@@ -79,22 +99,26 @@
       };
 
       var getPrompt = function() {
-        return prompt;
+        return currentRound.prompt;
       };
 
       var getMemes = function() {
-        return memes;
+        return currentRound.memes;
       };
 
       var getWinner = function() {
-        return winner;
+        return currentRound.winner;
       };
 
+      var started = function() {
+        return rounds.length > 0;
+      }
       return {
         on: registerEventHandler,
         getPrompt: getPrompt,
         getMemes: getMemes,
-        getWinner: getWinner
+        getWinner: getWinner,
+        started: started
       };
 
     });

--- a/client/chromecast-app/waiting/waiting.js
+++ b/client/chromecast-app/waiting/waiting.js
@@ -25,7 +25,8 @@
         }
       }
 
-    vm.currentDisplay = vm.mainContent['waitingForPlayers'];
+    var status = game.started() ? 'waitingForPrompt' : 'waitingForPlayers';
+    vm.currentDisplay = vm.mainContent[status]
 
     game.on('enoughPlayers', function() {
       vm.currentDisplay = vm.mainContent['readyToPlay'];

--- a/client/chromecast-app/winner/winner.js
+++ b/client/chromecast-app/winner/winner.js
@@ -5,12 +5,16 @@
     .module('app.winner')
     .controller('Winner', Winner);
 
-    Winner.$inject = ['game'];
+    Winner.$inject = ['$state', 'game'];
 
-    function Winner(game) {
+    function Winner($state, game) {
       var vm = this;
 
       vm.winner = game.getWinner();
+
+      game.on('startNextRound', function() {
+        $state.go('home.waiting');
+      });
 
     }
 

--- a/client/sender-app/layout/footer.html
+++ b/client/sender-app/layout/footer.html
@@ -1,3 +1,4 @@
 <footer data-ng-controller="Footer as vm">
   <span> This is the: {{ vm.test }} </span>
+  <button ng-if="vm.allowNextRound" ng-click="vm.startNextRound()">New Round</button>
 </footer>

--- a/client/sender-app/layout/footer.js
+++ b/client/sender-app/layout/footer.js
@@ -5,11 +5,22 @@
       .module('app.layout')
       .controller('Footer', Footer);
 
-  Footer.$inject = [];
+  Footer.$inject = ['playerMessenger'];
 
-  function Footer() {
+  function Footer(playerMessenger) {
     /*jshint validthis: true */
     var vm = this;
     vm.test = 'Footer';
+    
+    vm.allowNextRound = false;
+    playerMessenger.on('gameStarted', function () {
+      vm.allowNextRound = false;
+    });
+
+    playerMessenger.on('done', function () {
+      vm.allowNextRound = true;
+    });
+
+    vm.startNextRound = playerMessenger.startNextRound;
   }
 })();


### PR DESCRIPTION
This PR
- adds a button to start a new round
- makes the button appear only when the previous one is done
- adds tracking of round-specific info (start of game history...)
- adds support for multiple event handlers per event to player messenger (multiple places need to listen for gameStarted now)
- redirects Chromecast client to waiting screen on startNewRound. Players are given roles right away, so we're waiting for prompt
