### PR TITLE
(fix) Removed $apply() call from header.js

### DIFF
--- a/client/sender-app/layout/header.js
+++ b/client/sender-app/layout/header.js
@@ -18,9 +18,7 @@
     };
 
     playerMessenger.on('chromecastConnection', function(){
-      $rootScope.$apply(function() {
-        vm.castButtonState = playerMessenger.getConnectionStatus();
-      });
+      vm.castButtonState = playerMessenger.getConnectionStatus();
     });
   }
 })();


### PR DESCRIPTION
It's not needed anymore now that we have one wrapping all event handlers in player-messenger
