### PR TITLE
(refactor) move sender routes to root level

### DIFF
--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -9,7 +9,7 @@ module.exports = function (app, express) {
   app.use(cors());
   // explicitly naming all the folders where we're serving our different apps
   app.use('/cc', express.static(__dirname + '/../../client/chromecast-app'));
-  app.use('/sender', express.static(__dirname + '/../../client/sender-app'));
+  app.use('/', express.static(__dirname + '/../../client/sender-app'));
   // and their dependencies
   app.use('/core', express.static(__dirname + '/../../client/core'));
   app.use('/bower_components', express.static(__dirname + '/../../bower_components'));


### PR DESCRIPTION
This allows us to map play.memesformankind.com to the player app. Fixes #294 
