### PR TITLE
(fix) ios config && cast extension presence checking

### DIFF
--- a/client/core/chrome-detect.js
+++ b/client/core/chrome-detect.js
@@ -28,7 +28,7 @@
       // if the user doesn't have the chrome extension, tell them to get the cast extension
       // only actually check if they also don't have cordova and haven't loaded up the socket version
       // check browser first to avoid getting a null reference on cast.extensionId
-      browserHasExtension = (window.cordova || window.chrome.cast.extensionId || socketDev);
+      browserHasExtension = (window.cordova || window.chrome.cast || socketDev);
       return browserHasExtension;
     }
 

--- a/client/sender-app-mobile/plugins/ios.json
+++ b/client/sender-app-mobile/plugins/ios.json
@@ -5,15 +5,41 @@
     },
     "config_munge": {
         "files": {
+            "framework": {
+                "parents": {
+                    "libicucore.dylib": [
+                        {
+                            "xml": false,
+                            "count": 1
+                        }
+                    ],
+                    "Social.framework": [
+                        {
+                            "xml": true,
+                            "count": 1
+                        }
+                    ],
+                    "MessageUI.framework": [
+                        {
+                            "xml": true,
+                            "count": 1
+                        }
+                    ]
+                }
+            },
             "config.xml": {
                 "parents": {
                     "/*": [
                         {
-                            "xml": "<feature name=\"Console\"><param name=\"ios-package\" value=\"CDVLogger\" /></feature>",
+                            "xml": "<feature name=\"ConnectSDK\"><param name=\"ios-package\" value=\"ConnectSDKCordova\" /></feature>",
                             "count": 1
                         },
                         {
-                            "xml": "<feature name=\"ConnectSDK\"><param name=\"ios-package\" value=\"ConnectSDKCordova\" /></feature>",
+                            "xml": "<feature name=\"SocialSharing\"><param name=\"ios-package\" value=\"SocialSharing\" /><param name=\"onload\" value=\"true\" /></feature>",
+                            "count": 1
+                        },
+                        {
+                            "xml": "<feature name=\"Console\"><param name=\"ios-package\" value=\"CDVLogger\" /></feature>",
                             "count": 1
                         },
                         {
@@ -30,24 +56,17 @@
                         }
                     ]
                 }
-            },
-            "framework": {
-                "parents": {
-                    "libicucore.dylib": [
-                        {
-                            "xml": false,
-                            "count": 1
-                        }
-                    ]
-                }
             }
         }
     },
     "installed_plugins": {
-        "org.apache.cordova.console": {
+        "com.connectsdk.cordovaplugin": {
             "PACKAGE_NAME": "com.memesformankind.www"
         },
-        "com.connectsdk.cordovaplugin": {
+        "nl.x-services.plugins.socialsharing": {
+            "PACKAGE_NAME": "com.memesformankind.www"
+        },
+        "org.apache.cordova.console": {
             "PACKAGE_NAME": "com.memesformankind.www"
         },
         "org.apache.cordova.statusbar": {


### PR DESCRIPTION
tested in staging (thawing-eyrie)... works, giving correct error info for users in various situations:
1- non-chrome browser
2- missing chrome extension
3- accessing web version from a mobile device instead of the iOS or Android apps
